### PR TITLE
Fix errors from hc refactor & allow auth reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Required
 
 - `-homekit-pin [8-digits]` must be entered on iOS to pair with the light bulb(s)
 - `-nest-pin` authorization code from Nest - https://developer.nest.com/documentation/how-to-auth
+- `-nest-token` authorization token from Nest after successful authorization - https://developer.nest.com/documentation/how-to-auth
 - `-product-id` id of the product that you registered on the Nest developer portal
 - `-product-secret` secret key of the product that you registered on the Nest developer portal
 - `-state` a value you create, used during OAuth


### PR DESCRIPTION
- Update hc api calls to work with latest pkg
- Add `nest-token` flag to allow auth reuse

The nest-token removes the need to generate a new nest-token everytime
the app server is restarted

Also fixes #1 
